### PR TITLE
Refactor code for maintainability

### DIFF
--- a/src-tauri/src/simulations/flow/shaders/mod.rs
+++ b/src-tauri/src/simulations/flow/shaders/mod.rs
@@ -1,5 +1,5 @@
 pub const PARTICLE_UPDATE_SHADER: &str = include_str!("particle_update.wgsl");
-pub const PARTICLE_RENDER_SHADER: &str = include_str!("particle_render.wgsl");
+pub const PARTICLE_RENDER_SHADER: &str = include_str!("particle_render.wgsl"); // body will be prefixed with shared utils at module creation
 pub const TRAIL_DECAY_DIFFUSION_SHADER: &str = include_str!("trail_decay_diffusion.wgsl");
 pub const TRAIL_RENDER_SHADER: &str = include_str!("trail_render.wgsl");
 pub const BACKGROUND_RENDER_SHADER: &str = include_str!("background_render.wgsl");

--- a/src-tauri/src/simulations/flow/shaders/particle_update.wgsl
+++ b/src-tauri/src/simulations/flow/shaders/particle_update.wgsl
@@ -98,31 +98,6 @@ fn world_to_trail_coords(world_pos: vec2<f32>) -> vec2<f32> {
     return vec2<f32>(x, y);
 }
 
-// Convert from sRGB (gamma-corrected) to linear RGB
-fn srgb_to_linear(srgb: f32) -> f32 {
-    if (srgb <= 0.04045) {
-        return srgb / 12.92;
-    } else {
-        return pow((srgb + 0.055) / 1.055, 2.4);
-    }
-}
-
-// Get color from LUT
-fn get_lut_color(intensity: f32) -> vec3<f32> {
-    let lut_index = clamp(intensity * 255.0, 0.0, 255.0);
-    let index = u32(lut_index);
-    
-    // LUT data format: [r0, r1, ..., r255, g0, g1, ..., g255, b0, b1, ..., b255]
-    let r_srgb = f32(lut_data[index]) / 255.0;
-    let g_srgb = f32(lut_data[index + 256u]) / 255.0;
-    let b_srgb = f32(lut_data[index + 512u]) / 255.0;
-    
-    return vec3<f32>(
-        srgb_to_linear(r_srgb),
-        srgb_to_linear(g_srgb),
-        srgb_to_linear(b_srgb)
-    );
-}
 
 // Check if a point is inside the particle shape
 fn is_inside_particle_shape(offset_x: f32, offset_y: f32, radius: f32, shape: u32) -> bool {

--- a/src-tauri/src/simulations/flow/simulation.rs
+++ b/src-tauri/src/simulations/flow/simulation.rs
@@ -513,8 +513,9 @@ impl FlowModel {
         let common_layouts = CommonBindGroupLayouts::new(device);
 
         // Create particle update pipeline using GPU utilities
+        let particle_update_wgsl = format!("{}\n{}", crate::simulations::shared::COLOR_LUT_UTILS_WGSL, PARTICLE_UPDATE_SHADER);
         let particle_update_shader =
-            shader_manager.load_shader(device, "flow_particle_update", PARTICLE_UPDATE_SHADER);
+            shader_manager.load_shader(device, "flow_particle_update", &particle_update_wgsl);
 
         let compute_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -680,9 +681,10 @@ impl FlowModel {
             });
 
         // Create particle render pipeline
+        let particle_render_wgsl = format!("{}\n{}", crate::simulations::shared::COLOR_LUT_UTILS_WGSL, PARTICLE_RENDER_SHADER);
         let particle_render_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Flow Particle Render Shader"),
-            source: wgpu::ShaderSource::Wgsl(PARTICLE_RENDER_SHADER.into()),
+            source: wgpu::ShaderSource::Wgsl(particle_render_wgsl.into()),
         });
 
         let render_bind_group_layout =

--- a/src-tauri/src/simulations/pellets/shaders/particle_fragment_render.wgsl
+++ b/src-tauri/src/simulations/pellets/shaders/particle_fragment_render.wgsl
@@ -14,27 +14,7 @@ struct RenderParams {
 }
 
 @group(0) @binding(1) var<uniform> params: RenderParams;
-@group(0) @binding(2) var<storage, read> lut: array<u32>;
-
-// Convert from sRGB (gamma-corrected) to linear RGB
-fn srgb_to_linear(srgb: f32) -> f32 {
-    if (srgb <= 0.04045) {
-        return srgb / 12.92;
-    } else {
-        return pow((srgb + 0.055) / 1.055, 2.4);
-    }
-}
-
-fn get_lut_color(index: u32) -> vec3<f32> {
-    let r_srgb = f32(lut[index]) / 255.0;
-    let g_srgb = f32(lut[index + 256]) / 255.0;
-    let b_srgb = f32(lut[index + 512]) / 255.0;
-    return vec3<f32>(
-        srgb_to_linear(r_srgb),
-        srgb_to_linear(g_srgb),
-        srgb_to_linear(b_srgb)
-    );
-}
+@group(0) @binding(2) var<storage, read> lut_data: array<u32>;
 
 @fragment
 fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {

--- a/src-tauri/src/simulations/pellets/shaders/particle_render.wgsl
+++ b/src-tauri/src/simulations/pellets/shaders/particle_render.wgsl
@@ -28,27 +28,7 @@ struct VertexOutput {
 
 @group(0) @binding(0) var<storage, read> particles: array<Particle>;
 @group(0) @binding(1) var<uniform> params: RenderParams;
-@group(0) @binding(2) var<storage, read> lut: array<u32>;
-
-// Convert from sRGB (gamma-corrected) to linear RGB
-fn srgb_to_linear(srgb: f32) -> f32 {
-    if (srgb <= 0.04045) {
-        return srgb / 12.92;
-    } else {
-        return pow((srgb + 0.055) / 1.055, 2.4);
-    }
-}
-
-fn get_lut_color(index: u32) -> vec3<f32> {
-    let r_srgb = f32(lut[index]) / 255.0;
-    let g_srgb = f32(lut[index + 256]) / 255.0;
-    let b_srgb = f32(lut[index + 512]) / 255.0;
-    return vec3<f32>(
-        srgb_to_linear(r_srgb),
-        srgb_to_linear(g_srgb),
-        srgb_to_linear(b_srgb)
-    );
-}
+@group(0) @binding(2) var<storage, read> lut_data: array<u32>;
 
 fn get_particle_color(particle: Particle) -> vec3<f32> {
     // Color based on mass and clump id

--- a/src-tauri/src/simulations/pellets/simulation.rs
+++ b/src-tauri/src/simulations/pellets/simulation.rs
@@ -388,9 +388,10 @@ impl PelletsModel {
         });
 
         // Create render shaders using GPU utilities
+        let pellets_render_wgsl = format!("{}\n{}", crate::simulations::shared::COLOR_LUT_UTILS_WGSL, super::shaders::PARTICLE_RENDER_SHADER);
         let render_shader = Arc::new(device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("pellets_render"),
-            source: wgpu::ShaderSource::Wgsl(super::shaders::PARTICLE_RENDER_SHADER.into()),
+            source: wgpu::ShaderSource::Wgsl(pellets_render_wgsl.into()),
         }));
 
         let render_bind_group_layout =
@@ -574,9 +575,10 @@ impl PelletsModel {
             .build();
 
         // Create background pipeline
+        let pellets_background_wgsl = format!("{}\n{}", crate::simulations::shared::COLOR_LUT_UTILS_WGSL, super::shaders::BACKGROUND_RENDER_SHADER);
         let background_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Pellets Background Shader"),
-            source: wgpu::ShaderSource::Wgsl(super::shaders::BACKGROUND_RENDER_SHADER.into()),
+            source: wgpu::ShaderSource::Wgsl(pellets_background_wgsl.into()),
         });
 
         // Create dummy texture for density visualization

--- a/src-tauri/src/simulations/shared/color_lut_utils.wgsl
+++ b/src-tauri/src/simulations/shared/color_lut_utils.wgsl
@@ -1,0 +1,24 @@
+fn srgb_to_linear(srgb: f32) -> f32 {
+    if (srgb <= 0.04045) {
+        return srgb / 12.92;
+    } else {
+        return pow((srgb + 0.055) / 1.055, 2.4);
+    }
+}
+
+fn get_lut_color(index: u32) -> vec3<f32> {
+    // LUT data format: [r0..r255, g0..g255, b0..b255]
+    let r_srgb = f32(lut_data[index]) / 255.0;
+    let g_srgb = f32(lut_data[index + 256u]) / 255.0;
+    let b_srgb = f32(lut_data[index + 512u]) / 255.0;
+    return vec3<f32>(
+        srgb_to_linear(r_srgb),
+        srgb_to_linear(g_srgb),
+        srgb_to_linear(b_srgb)
+    );
+}
+
+fn get_lut_color_from_intensity(intensity: f32) -> vec3<f32> {
+    let lut_index = clamp(intensity * 255.0, 0.0, 255.0);
+    return get_lut_color(u32(lut_index));
+}

--- a/src-tauri/src/simulations/shared/mod.rs
+++ b/src-tauri/src/simulations/shared/mod.rs
@@ -37,3 +37,4 @@ pub use post_processing::{PostProcessingResources, PostProcessingState};
 
 pub const INFINITE_RENDER_SHADER: &str = include_str!("infinite_render.wgsl");
 pub const AVERAGE_COLOR_SHADER: &str = include_str!("average_color.wgsl");
+pub const COLOR_LUT_UTILS_WGSL: &str = include_str!("color_lut_utils.wgsl");


### PR DESCRIPTION
Extract common WGSL color and LUT utility functions into a shared module to reduce code duplication and improve maintainability.

This centralizes `srgb_to_linear`, `get_lut_color`, and `get_lut_color_from_intensity` functions, which were previously duplicated across Flow and Pellets shaders.

---
<a href="https://cursor.com/background-agent?bcId=bc-86eef437-a1fa-47dd-a8da-ae9f3c3c5eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86eef437-a1fa-47dd-a8da-ae9f3c3c5eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

